### PR TITLE
Scale factor

### DIFF
--- a/btg_to_ac3d_2.py
+++ b/btg_to_ac3d_2.py
@@ -45,46 +45,6 @@ MaterialListGreen = { }
 MaterialListAlpha = { }
 
 class BTG:
-  f = None
-  mesh = None
-  scn = None
-
-  name = ""
-  base = ""
-  index = 0
-
-  x = 0
-  y = 0
-  lat = 0
-  lon = 0
-  center_lat = 0
-  center_lon = 0
-
-  boundingspheres = []
-  vertices = []
-  normals = []
-  texcoords = []
-  colors = []
-  points = []
-  faces = []
-
-  faceidx = []
-  normalidx = []
-  texcoordidx = []
-  coloridx = []
-
-  objvertices = []
-
-  nobjects = 0
-  objects = []
-
-  readers = []
-  materials = []
-  material = ""
-  materialname = ""
-
-  matrix = None
-
 # Helper functions
 
   # Returns the tile width in degrees on current latitude
@@ -584,6 +544,46 @@ class BTG:
 
   # Main loader
   def __init__(self, path, outfile, batch = False):
+    self.f = None
+    self.mesh = None
+    self.scn = None
+
+    self.name = ""
+    self.base = ""
+    self.index = 0
+
+    self.x = 0
+    self.y = 0
+    self.lat = 0
+    self.lon = 0
+    self.center_lat = 0
+    self.center_lon = 0
+
+    self.boundingspheres = []
+    self.vertices = []
+    self.normals = []
+    self.texcoords = []
+    self.colors = []
+    self.points = []
+    self.faces = []
+
+    self.faceidx = []
+    self.normalidx = []
+    self.texcoordidx = []
+    self.coloridx = []
+
+    self.objvertices = []
+
+    self.nobjects = 0
+    self.objects = []
+
+    self.readers = []
+    self.materials = []
+    self.material = ""
+    self.materialname = ""
+
+    self.matrix = None
+
     if batch:
       try:
         files= [ f for f in os.listdir(path) if f.lower().endswith('.btg.gz') or f.lower().endswith('.btg')]

--- a/btg_to_ac3d_2.py
+++ b/btg_to_ac3d_2.py
@@ -234,7 +234,11 @@ class BTG:
 
       for n in range(0, int(nbytes/12)):    # One vertex is 12 bytes (3 * 4 bytes)
         (v_x, v_y, v_z) = unpack("<fff", data[n*12:(n+1)*12])
-        self.vertices.append({"x":scale_factor*v_x, "y":scale_factor*v_y, "z":scale_factor*v_z})
+        if scale_factor == 1:
+            # No scaling required
+            self.vertices.append({"x":v_x, "y":v_y, "z":v_z})
+        else:
+            self.vertices.append({"x":scale_factor*v_x, "y":scale_factor*v_y, "z":scale_factor*v_z})
 
     elif objtype == NORMALLIST:
       for n in range(0, int(nbytes/3)):    # One normal is 3 bytes ( 3 * 1 )

--- a/concat_ac3.py
+++ b/concat_ac3.py
@@ -157,6 +157,8 @@ def main(STGFile_path):
             splitLine = line.strip().split(" ");
             if len(splitLine) > 1:
                 if splitLine[0] == "OBJECT_SHARED":
+                    # TODO: for 958401-test.stg, this will mean splitExtension[0] == 'Models/Airport/thangar'
+                    # Is that correct, or should it just be splitExtension[0] == 'thangar' ?
                     splitExtension = splitLine[1].split(".")
                     if splitExtension[len(splitExtension) - 1] == "ac":
                         # print(splitLine[1]) #ac file name

--- a/concat_ac3.py
+++ b/concat_ac3.py
@@ -55,8 +55,12 @@ def processACFile(ACFilePath, splitExtension, splitLine, globalMaterials=None, m
             if numvert is not None:
                 # We're in a vert block
                 scale_factor = float(os.environ.get("SCALE_FACTOR", "0.001"))
-                vert = [float(el)/scale_factor for el in line2.strip().split(" ")]  # dividing, opposite of btg_to_ac3d_2
-                mainBody.append(" ".join([str(el) for el in vert]))
+                if scale_factor == 1:
+                    # No scaling required so leave the line of text unchanged
+                    mainBody.append(line2.strip())
+                else:
+                    vert = [scale_factor*float(el) for el in line2.strip().split(" ")]
+                    mainBody.append(" ".join([str(el) for el in vert]))
                 verts_written += 1
                 if verts_written == numvert:
                     # end of block of verts

--- a/concat_ac3.py
+++ b/concat_ac3.py
@@ -45,6 +45,7 @@ def processACFile(ACFilePath, splitExtension, splitLine, globalMaterials=None, m
         globalMaterials = []
     if mainBody is None:
         mainBody = []
+    scale_factor = float(os.environ.get("SCALE_FACTOR", "0.001"))
 
     materialsRelationship = []
 
@@ -54,7 +55,6 @@ def processACFile(ACFilePath, splitExtension, splitLine, globalMaterials=None, m
         for line2 in ACFile:
             if numvert is not None:
                 # We're in a vert block
-                scale_factor = float(os.environ.get("SCALE_FACTOR", "0.001"))
                 if scale_factor == 1:
                     # No scaling required so leave the line of text unchanged
                     mainBody.append(line2.strip())
@@ -126,6 +126,11 @@ def processACFile(ACFilePath, splitExtension, splitLine, globalMaterials=None, m
                 #temp = geodToCart(37.5, -122.7, 1000)
 
                 convertedCoords = geodToCart(lat, lon, alt)
+                if scale_factor == 1:
+                    scaled_alt = alt
+                else:
+                    convertedCoords = [scale_factor*float(el) for el in convertedCoords]
+                    scaled_alt = scale_factor*alt
 
                 #mainBody.append(
                 #    "loc " + str(convertedCoords[2]) + " " + str(convertedCoords[1]) + " " + str(
@@ -135,7 +140,7 @@ def processACFile(ACFilePath, splitExtension, splitLine, globalMaterials=None, m
                 #    alt))
 
                 mainBody.append(
-                    "loc " + str(convertedCoords[1]) + " " + str(convertedCoords[0]) + " " + str(alt))
+                    "loc " + str(convertedCoords[1]) + " " + str(convertedCoords[0]) + " " + str(scaled_alt))
                 # mainBody.append("loc " + str(lon) + " " + str(lat) + " " + str(rad))
             else:
                 splitLine2 = line2.strip().split(" ")

--- a/concat_ac3.py
+++ b/concat_ac3.py
@@ -7,9 +7,6 @@ import os
 from pathlib import Path
 import sys
 
-globalMaterials = []
-mainBody = []
-numberOfObjects = 0
 
 FG_ROOT = os.environ.get("FG_ROOT", "/usr/share/games/flightgear/")
 
@@ -43,10 +40,11 @@ def geodToCart(lat, lon, alt):
     z = (h + n - e2 * n) * sphi
     return x, y, z
 
-def processACFile(ACFilePath, splitExtension, splitLine):
-    global globalMaterials
-    global mainBody
-    global numberOfObjects
+def processACFile(ACFilePath, splitExtension, splitLine, globalMaterials=None, mainBody=None, numberOfObjects=0):
+    if globalMaterials is None:
+        globalMaterials = []
+    if mainBody is None:
+        mainBody = []
 
     materialsRelationship = []
 
@@ -144,7 +142,12 @@ def processACFile(ACFilePath, splitExtension, splitLine):
                         mainBody.append(line2.strip())
     ACFile.close()
 
+    return globalMaterials, mainBody, numberOfObjects
+
 def main(STGFile_path):
+    globalMaterials = []
+    mainBody = []
+    numberOfObjects = 0
 
     if FG_ROOT is not None:
         # Open a file
@@ -161,7 +164,8 @@ def main(STGFile_path):
 
                         try:
                             ACFilePath = FG_ROOT + splitLine[1]
-                            processACFile(ACFilePath, splitExtension, splitLine)
+                            globalMaterials, mainBody, numberOfObjects = processACFile(
+                                ACFilePath, splitExtension, splitLine, globalMaterials, mainBody, numberOfObjects)
                             lockedAndLoaded = 1
                         except IOError:
                             lockedAndLoaded = 0
@@ -169,7 +173,8 @@ def main(STGFile_path):
                         if lockedAndLoaded == 0:
                             try:
                                 ACFilePath = FG_SCENERY + splitLine[1]
-                                processACFile(ACFilePath, splitExtension, splitLine)
+                                globalMaterials, mainBody, numberOfObjects = processACFile(
+                                    ACFilePath, splitExtension, splitLine, globalMaterials, mainBody, numberOfObjects)
                                 lockedAndLoaded = 1
                             except IOError:
                                 lockedAndLoaded = 0
@@ -177,7 +182,8 @@ def main(STGFile_path):
                         if lockedAndLoaded == 0:
                             try:
                                 ACFilePath = os.path.dirname(sys.argv[1]) + "/" + splitLine[1]
-                                processACFile(ACFilePath, splitExtension, splitLine)
+                                globalMaterials, mainBody, numberOfObjects = processACFile(
+                                    ACFilePath, splitExtension, splitLine, globalMaterials, mainBody, numberOfObjects)
                                 lockedAndLoaded = 1
                             except IOError:
                                 print("Could not open " + splitLine[1])

--- a/tests/TO_RUN_THESE_TESTS.txt
+++ b/tests/TO_RUN_THESE_TESTS.txt
@@ -16,4 +16,4 @@ Then you can run the following tests
 
 	testPlacement.sh is for checking the geometry is correct for the resulting AC3D. Placement is manually verified using fgfs from flightgear.
 	buildLondon.sh converts some scenery of London, UK to AC3D files
-	test_concat_ac3.py runs some python tests on the code
+	test_btg_to_ac3d_2.py and test_concat_ac3.py run some automated Python tests on the code. test_concat_ac3() is good for test-running overall concat_ac3.py functionality.

--- a/tests/test_btg_to_ac3d_2.py
+++ b/tests/test_btg_to_ac3d_2.py
@@ -1,0 +1,61 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from btg_to_ac3d_2 import main
+
+
+def find_file(file_name, directory):
+    for root, _, files in os.walk(directory):
+        if file_name in files:
+            return (Path(root) / file_name).resolve()
+    return None
+
+
+@pytest.fixture()
+def btg_filepath():
+    btg_file = "2582409.btg.gz"
+    project_root = Path(__file__).resolve().parent.parent  # dir that contains tests/
+    file_path = find_file(btg_file, project_root)
+    if file_path:
+        return file_path
+    raise FileNotFoundError(f"The file '{btg_file}' was not found in the project root or its subdirectories.")
+    
+
+def test_scale_factor(btg_filepath, tmp_path, monkeypatch):
+    """Run with different SCALE_FACTOR values and compare"""
+    FG_ROOT = "/home/x/PycharmProjects/flightgear_export_scripts/fg_install/fgdata/fgdata/"
+    monkeypatch.setenv("FG_ROOT", FG_ROOT)
+    monkeypatch.setattr("btg_to_ac3d_2.FG_ROOT", FG_ROOT)
+
+    verts = {}
+    for scale_factor in ("0.001", "0.05", "0.01", "0.1", "1", "2", "3"):
+        verts[scale_factor] = []
+        monkeypatch.setenv("SCALE_FACTOR", scale_factor)
+
+        outpath = tmp_path / f"test_scale_factor_{scale_factor}.ac"
+        main(str(btg_filepath), str(outpath))
+
+        # Parse out the verts for later comparison
+        numvert = None
+        verts_stored = None
+        with open(outpath, "r") as f:
+            for line in f:
+                if numvert is not None:
+                    # We're in a block of verts
+                    verts[scale_factor].append([float(el) for el in line.split()])
+                    verts_stored += 1
+                    if verts_stored == numvert:
+                        # end of block of verts
+                        numvert = None
+                        verts_stored = None
+                else:
+                    # We're not in a block of verts
+                    if line.startswith("numvert"):
+                        # block of verts found
+                        numvert = int(line.split()[1])
+                        verts_stored = 0
+
+    from pprint import pprint
+    pprint(verts)

--- a/tests/test_btg_to_ac3d_2.py
+++ b/tests/test_btg_to_ac3d_2.py
@@ -15,6 +15,12 @@ def find_file(file_name, directory):
 
 @pytest.fixture()
 def btg_filepath():
+    """
+    This fixture looks for the stated BTG file anywhere within the project root or its subdirectories.
+    You will need to copy the stated BTG file into the project somewhere, if it's not there already.
+    If you don't have the stated BTG file, some other one (with verts) should work too - just change `btg_file`.
+    Or if you don't want to copy it into the project, change `file_path` to the full path of the BTG file.
+    """
     btg_file = "2582409.btg.gz"
     project_root = Path(__file__).resolve().parent.parent  # dir that contains tests/
     file_path = find_file(btg_file, project_root)
@@ -25,9 +31,9 @@ def btg_filepath():
 
 def test_scale_factor(btg_filepath, tmp_path, monkeypatch):
     """Run with different SCALE_FACTOR values and compare"""
-    FG_ROOT = "/home/x/PycharmProjects/flightgear_export_scripts/fg_install/fgdata/fgdata/"
-    monkeypatch.setenv("FG_ROOT", FG_ROOT)
-    monkeypatch.setattr("btg_to_ac3d_2.FG_ROOT", FG_ROOT)
+    # FG_ROOT = "/home/x/PycharmProjects/flightgear_export_scripts/fg_install/fgdata/fgdata/"
+    # monkeypatch.setenv("FG_ROOT", FG_ROOT)
+    # monkeypatch.setattr("btg_to_ac3d_2.FG_ROOT", FG_ROOT)
 
     verts = {}
     for scale_factor in ("0.001", "0.05", "0.01", "0.1", "1", "2", "3"):
@@ -57,5 +63,20 @@ def test_scale_factor(btg_filepath, tmp_path, monkeypatch):
                         numvert = int(line.split()[1])
                         verts_stored = 0
 
-    from pprint import pprint
-    pprint(verts)
+    # Test that SCALE_FACTOR has applied correctly by reversing it,
+    # and checking that the (original) verts we get back are identical again
+    orig_verts = {}
+    for scale_factor, verts_list in verts.items():
+        sf = float(scale_factor)
+        orig_verts[scale_factor] = [
+            [v/sf for v in verts]
+            for verts in verts_list
+        ]
+
+    expected = next(iter(orig_verts.values()))  # just take one to compare against, we don't care which one
+    for scale_factor, verts_list in orig_verts.items():
+        for i in range(len(verts_list)):
+            assert (
+                expected[i] == pytest.approx(verts_list[i]),  # approx due to float rounding error
+                f"Expected verts to be identical for scale factor {scale_factor}"
+            )

--- a/tests/test_btg_to_ac3d_2.py
+++ b/tests/test_btg_to_ac3d_2.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from btg_to_ac3d_2 import main
-from .utils import parse_verts_from_ac
+from .utils import parse_verts_from_ac, reverse_scale_factor
 
 
 def find_file(file_name, directory):
@@ -48,13 +48,7 @@ def test_scale_factor(btg_filepath, tmp_path, monkeypatch):
 
     # Test that SCALE_FACTOR has applied correctly by reversing it,
     # and checking that the (original) verts we get back are identical again
-    orig_verts = {}
-    for scale_factor, verts_list in verts.items():
-        sf = float(scale_factor)
-        orig_verts[scale_factor] = [
-            [v/sf for v in verts]
-            for verts in verts_list
-        ]
+    orig_verts = reverse_scale_factor(verts)
 
     expected = next(iter(orig_verts.values()))  # just take one to compare against, we don't care which one
     for scale_factor, verts_list in orig_verts.items():

--- a/tests/test_concat_ac3.py
+++ b/tests/test_concat_ac3.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import pytest
@@ -15,20 +16,24 @@ def stg_filepath():
 
 def test_concat_ac3(stg_filepath, monkeypatch):
     """High-level "smoke test" to check it runs without errors."""
-    FG_ROOT = "/home/x/PycharmProjects/flightgear_export_scripts/fg_install/fgdata/fgdata/"
-    monkeypatch.setenv("FG_ROOT", FG_ROOT)
-    monkeypatch.setattr("concat_ac3.FG_ROOT", FG_ROOT)
-
-    FG_SCENERY = "/home/x/PycharmProjects/flightgear_export_scripts/fg_install/fgdata/fgdata/Scenery/SceneryPack.BIKF/"
-    monkeypatch.setenv("FG_SCENERY", FG_SCENERY)
-    monkeypatch.setattr("concat_ac3.FG_SCENERY", FG_SCENERY)
+    # FG_ROOT = "/home/x/PycharmProjects/flightgear_export_scripts/fg_install/fgdata/fgdata/"
+    # monkeypatch.setenv("FG_ROOT", FG_ROOT)
+    # monkeypatch.setattr("concat_ac3.FG_ROOT", FG_ROOT)
+    #
+    # FG_SCENERY = "/home/x/PycharmProjects/flightgear_export_scripts/fg_install/fgdata/fgdata/Scenery/SceneryPack.BIKF/"
+    # monkeypatch.setenv("FG_SCENERY", FG_SCENERY)
+    # monkeypatch.setattr("concat_ac3.FG_SCENERY", FG_SCENERY)
 
     concat_ac3.main(STGFile_path=stg_filepath)
 
 
 def test_scale_factor(monkeypatch):
     """Run with different SCALE_FACTOR values and compare"""
-    ACFilePath = '/home/x/PycharmProjects/flightgear_export_scripts/fg_install/fgdata/fgdata/Scenery/SceneryPack.BIKF/Models/Airport/thangar.ac'
+    # FG_ROOT = "/home/x/PycharmProjects/flightgear_export_scripts/fg_install/fgdata/fgdata/"
+    # monkeypatch.setenv("FG_ROOT", FG_ROOT)
+
+    FG_ROOT = os.environ["FG_ROOT"]
+    ACFilePath = str(Path(FG_ROOT) / 'Scenery/SceneryPack.BIKF/Models/Airport/thangar.ac')
     splitExtension = ['Models/Airport/thangar', 'ac']
     splitLine = ['OBJECT_SHARED', 'Models/Airport/thangar.ac', '-121.60000000', '37.0810000', '84.0', '204']
 

--- a/tests/test_concat_ac3.py
+++ b/tests/test_concat_ac3.py
@@ -3,13 +3,14 @@ from pathlib import Path
 import pytest
 
 import concat_ac3
+from .utils import parse_verts_from_ac
 
 #Authors: benxyzzy
 
 
 @pytest.fixture()
 def stg_filepath():
-    return Path("./958401-test.stg").resolve()
+    return (Path(__file__).parent / "958401-test.stg").resolve()
 
 
 def test_concat_ac3(stg_filepath, monkeypatch):
@@ -26,4 +27,13 @@ def test_concat_ac3(stg_filepath, monkeypatch):
 
 
 def test_scale_factor():
-    pass
+    ACFilePath = '/home/x/PycharmProjects/flightgear_export_scripts/fg_install/fgdata/fgdata/Scenery/SceneryPack.BIKF/Models/Airport/thangar.ac'
+    splitExtension = ['Models/Airport/thangar', 'ac']
+    splitLine = ['OBJECT_SHARED', 'Models/Airport/thangar.ac', '-121.60000000', '37.0810000', '84.0', '204']
+
+    globalMaterials, mainBody, numberOfObjects = concat_ac3.processACFile(ACFilePath, splitExtension, splitLine)
+
+    verts = parse_verts_from_ac(mainBody)
+
+    from pprint import pprint
+    pprint(verts)

--- a/tests/test_concat_ac3.py
+++ b/tests/test_concat_ac3.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 import concat_ac3
-from .utils import parse_verts_from_ac
+from .utils import parse_verts_from_ac, reverse_scale_factor
 
 #Authors: benxyzzy
 
@@ -26,14 +26,27 @@ def test_concat_ac3(stg_filepath, monkeypatch):
     concat_ac3.main(STGFile_path=stg_filepath)
 
 
-def test_scale_factor():
+def test_scale_factor(monkeypatch):
+    """Run with different SCALE_FACTOR values and compare"""
     ACFilePath = '/home/x/PycharmProjects/flightgear_export_scripts/fg_install/fgdata/fgdata/Scenery/SceneryPack.BIKF/Models/Airport/thangar.ac'
     splitExtension = ['Models/Airport/thangar', 'ac']
     splitLine = ['OBJECT_SHARED', 'Models/Airport/thangar.ac', '-121.60000000', '37.0810000', '84.0', '204']
 
-    globalMaterials, mainBody, numberOfObjects = concat_ac3.processACFile(ACFilePath, splitExtension, splitLine)
+    verts = {}
+    for scale_factor in ("0.001", "0.05", "0.01", "0.1", "1", "2", "3"):
+        monkeypatch.setenv("SCALE_FACTOR", scale_factor)
 
-    verts = parse_verts_from_ac(mainBody)
+        globalMaterials, mainBody, numberOfObjects = concat_ac3.processACFile(ACFilePath, splitExtension, splitLine)
 
-    from pprint import pprint
-    pprint(verts)
+        verts[scale_factor] = parse_verts_from_ac(mainBody)
+
+    # Test that SCALE_FACTOR has applied correctly by reversing it,
+    # and checking that the (original) verts we get back are identical again
+    orig_verts = reverse_scale_factor(verts, divided=True)
+
+    expected = next(iter(orig_verts.values()))  # just take one to compare against, we don't care which one
+    for scale_factor, verts_list in orig_verts.items():
+        for i in range(len(verts_list)):
+            # approx due to float rounding error
+            assert expected[i] == pytest.approx(verts_list[i]), \
+                f"Expected verts to be identical for scale factor {scale_factor}"

--- a/tests/test_concat_ac3.py
+++ b/tests/test_concat_ac3.py
@@ -7,11 +7,23 @@ import concat_ac3
 #Authors: benxyzzy
 
 
-@pytest.fixture(params=[pytest.param(None, marks=pytest.mark.xfail(reason="This is not the correct test data"))])
+@pytest.fixture()
 def stg_filepath():
-    # return Path("./958401.stg").resolve()
     return Path("./958401-test.stg").resolve()
 
 
-def test_concat_ac3(stg_filepath):
+def test_concat_ac3(stg_filepath, monkeypatch):
+    """High-level "smoke test" to check it runs without errors."""
+    FG_ROOT = "/home/x/PycharmProjects/flightgear_export_scripts/fg_install/fgdata/fgdata/"
+    monkeypatch.setenv("FG_ROOT", FG_ROOT)
+    monkeypatch.setattr("concat_ac3.FG_ROOT", FG_ROOT)
+
+    FG_SCENERY = "/home/x/PycharmProjects/flightgear_export_scripts/fg_install/fgdata/fgdata/Scenery/SceneryPack.BIKF/"
+    monkeypatch.setenv("FG_SCENERY", FG_SCENERY)
+    monkeypatch.setattr("concat_ac3.FG_SCENERY", FG_SCENERY)
+
     concat_ac3.main(STGFile_path=stg_filepath)
+
+
+def test_scale_factor():
+    pass

--- a/tests/test_concat_ac3.py
+++ b/tests/test_concat_ac3.py
@@ -1,3 +1,7 @@
+"""
+These tests rely on your FG_ROOT containing the file in the ACFilePath variable.
+"""
+
 import os
 from pathlib import Path
 

--- a/tests/test_concat_ac3.py
+++ b/tests/test_concat_ac3.py
@@ -51,7 +51,7 @@ def test_scale_factor(monkeypatch):
 
     # Test that SCALE_FACTOR has applied correctly by reversing it,
     # and checking that the (original) verts we get back are identical again
-    orig_verts = reverse_scale_factor(verts, divided=True)
+    orig_verts = reverse_scale_factor(verts)
 
     expected = next(iter(orig_verts.values()))  # just take one to compare against, we don't care which one
     for scale_factor, verts_list in orig_verts.items():

--- a/tests/test_concat_ac3.py
+++ b/tests/test_concat_ac3.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 import concat_ac3
@@ -5,9 +7,10 @@ import concat_ac3
 #Authors: benxyzzy
 
 
-@pytest.fixture
+@pytest.fixture(params=[pytest.param(None, marks=pytest.mark.xfail(reason="This is not the correct test data"))])
 def stg_filepath():
-    return "./958401.stg"
+    # return Path("./958401.stg").resolve()
+    return Path("./958401-test.stg").resolve()
 
 
 def test_concat_ac3(stg_filepath):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -28,7 +28,7 @@ def parse_verts_from_ac(f):
     return verts
 
 
-def reverse_scale_factor(scale_factor_verts_dict, divided=False):
+def reverse_scale_factor(scale_factor_verts_dict):
     """
     If you apply different scale factors to a list of verts,
     and store them in a dict with the scale factor as the key,
@@ -44,19 +44,13 @@ def reverse_scale_factor(scale_factor_verts_dict, divided=False):
          '0.05': [[129.930058, 104.69998399999999, 964.6286779999999],
                   [129.930058, 1.07406, 964.6286779999999],
                   [-130.06996199999998, 1.07408, 964.6286779999999]]}
-    :param divided: How the original scaling to be reversed was applied: by multiplying (default) or dividing.
     :returns: a dict with the same format and keys, but where the scaling on each element has been reversed.
     """
-    if divided:
-        op = operator.mul
-    else:
-        op = operator.truediv
-
     orig_verts = {}
     for scale_factor, verts_list in scale_factor_verts_dict.items():
         sf = float(scale_factor)
         orig_verts[scale_factor] = [
-            [op(v, sf) for v in verts]
+            [v/sf for v in verts]
             for verts in verts_list
         ]
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,26 @@
+def parse_verts_from_ac(f):
+    """
+    Take an opened AC file (or contents as a list of lines) and return all the verts.
+    They are returned in the same order as they appear in the file, so can be used to compare files by their verts.
+    """
+    verts = []
+
+    numvert = None
+    verts_stored = None
+    for line in f:
+        if numvert is not None:
+            # We're in a block of verts
+            verts.append([float(el) for el in line.split()])
+            verts_stored += 1
+            if verts_stored == numvert:
+                # end of block of verts
+                numvert = None
+                verts_stored = None
+        else:
+            # We're not in a block of verts
+            if line.startswith("numvert"):
+                # block of verts found
+                numvert = int(line.split()[1])
+                verts_stored = 0
+
+    return verts

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -49,9 +49,14 @@ def reverse_scale_factor(scale_factor_verts_dict):
     orig_verts = {}
     for scale_factor, verts_list in scale_factor_verts_dict.items():
         sf = float(scale_factor)
-        orig_verts[scale_factor] = [
-            [v/sf for v in verts]
-            for verts in verts_list
-        ]
+
+        try:
+            orig_verts[scale_factor] = [
+                [v/sf for v in verts]
+                for verts in verts_list
+            ]
+        except TypeError as ex:  # 'float' object is not iterable
+            # Now we can reverse lists of scalars as well as lists of verts
+            orig_verts[scale_factor] = [v/sf for v in verts_list]
 
     return orig_verts

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,5 @@
+import operator
+
 def parse_verts_from_ac(f):
     """
     Take an opened AC file (or contents as a list of lines) and return all the verts.
@@ -24,3 +26,38 @@ def parse_verts_from_ac(f):
                 verts_stored = 0
 
     return verts
+
+
+def reverse_scale_factor(scale_factor_verts_dict, divided=False):
+    """
+    If you apply different scale factors to a list of verts,
+    and store them in a dict with the scale factor as the key,
+    then this function returns a dict with the scaling undone.
+
+    :param scale_factor_verts_dict: takes the format of e.g.
+        {'0.001': [[6496.5029, 5234.999199999999, 48231.433899999996],
+                   [6496.5029, 53.703, 48231.433899999996],
+                   [-6503.4981, 53.704, 48231.433899999996]],
+         '0.01': [[649.65029, 523.49992, 4823.14339],
+                  [649.65029, 5.3703, 4823.14339],
+                  [-650.3498099999999, 5.3704, 4823.14339]],
+         '0.05': [[129.930058, 104.69998399999999, 964.6286779999999],
+                  [129.930058, 1.07406, 964.6286779999999],
+                  [-130.06996199999998, 1.07408, 964.6286779999999]]}
+    :param divided: How the original scaling to be reversed was applied: by multiplying (default) or dividing.
+    :returns: a dict with the same format and keys, but where the scaling on each element has been reversed.
+    """
+    if divided:
+        op = operator.mul
+    else:
+        op = operator.truediv
+
+    orig_verts = {}
+    for scale_factor, verts_list in scale_factor_verts_dict.items():
+        sf = float(scale_factor)
+        orig_verts[scale_factor] = [
+            [op(v, sf) for v in verts]
+            for verts in verts_list
+        ]
+
+    return orig_verts


### PR DESCRIPTION
Added a `SCALE_FACTOR` env var, which defaults to 0.001.

In `btg_to_ac3d_2.py`, verts are multiplied by this number (this is the same as how it used to work, dividing by 1000)

In `concat_ac3.py`, verts and the `loc` output param are multiplied by this number (this is new, so as to match `btg_to_ac3d_2.py` for compatibility)

I refactored both scripts to make them easier to test using pytest, but the behaviour should not have changed (other than the new `SCALE_FACTOR`)

I also did some slight miscellaneous tidying and added a couple of pytest tests.