### PR TITLE
Scenery object loc mismatch

### DIFF
--- a/concat_ac3.py
+++ b/concat_ac3.py
@@ -67,12 +67,14 @@ def processACFile(ACFilePath, splitExtension, splitLine, globalMaterials=None, m
                     numvert = None
                     verts_written = None
             elif line2.strip().startswith("numvert "):
-                # Start of vert block
+                # Possible start of vert block
                 splitLine2 = line2.strip().split(" ")
-                numvert = int(splitLine2[1])
-                verts_written = 0
+                this_numvert = int(splitLine2[1])
+                if this_numvert > 0:
+                    numvert = this_numvert
+                    verts_written = 0
 
-                mainBody.append(line2.strip())
+                    mainBody.append(line2.strip())
             elif line2.strip() == "AC3Db":
                 continue
             elif line2.strip() == "OBJECT world":

--- a/concat_ac3.py
+++ b/concat_ac3.py
@@ -7,6 +7,9 @@ import os
 from pathlib import Path
 import sys
 
+import inspect
+import traceback
+
 
 FG_ROOT = os.environ.get("FG_ROOT", "/usr/share/games/flightgear/")
 
@@ -15,6 +18,41 @@ FG_SCENERY = os.environ.get("FG_SCENERY", "/usr/share/games/flightgear/Scenery/"
 def usage():
     print("Usage: python concat_ac3.py [file]")
     return
+
+
+def log_exceptions(exclude_args=None, exclude_exceptions=None):
+    if exclude_args is None:
+        exclude_args = set()
+    if exclude_exceptions is None:
+        exclude_exceptions = tuple()
+    else:
+        exclude_exceptions = tuple(exclude_exceptions)
+
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except exclude_exceptions:
+                raise
+            except Exception:
+                # Get function signature to match args to parameter names
+                sig = inspect.signature(func)
+                bound_args = sig.bind_partial(*args, **kwargs)
+                bound_args.apply_defaults()  # Ensure defaults are included
+
+                # Filter out excluded arguments
+                filtered_args = {k: v for k, v in bound_args.arguments.items() if k not in exclude_args}
+
+                print(f"Exception in function: {func.__name__}", file=sys.stderr)
+                print(f"Arguments (excluding {exclude_args}): {filtered_args}", file=sys.stderr)
+                print("Traceback:", file=sys.stderr)
+                traceback.print_exc(file=sys.stderr)
+
+                raise
+
+        return wrapper
+
+    return decorator
 
 
 # Convert geodetic coordinates to Cartesian
@@ -40,6 +78,7 @@ def geodToCart(lat, lon, alt):
     z = (h + n - e2 * n) * sphi
     return x, y, z
 
+@log_exceptions(exclude_args={"globalMaterials", "mainBody"}, exclude_exceptions=(FileNotFoundError,))
 def processACFile(ACFilePath, splitExtension, splitLine, globalMaterials=None, mainBody=None, numberOfObjects=0):
     if globalMaterials is None:
         globalMaterials = []

--- a/tests/buildScenery.sh
+++ b/tests/buildScenery.sh
@@ -30,41 +30,44 @@ find "${FG_ROOT}Scenery/${scenery_b}/Terrain" -maxdepth 2 -mindepth 2 -type d | 
       ''|*[!0-9]*) echo "Can't get lonlat from $fname, skipping..." ; continue ;;
     esac
 
+    fn_subdir_subdir="$(printf "%s" "${abtg}" | rev | cut -d "/" -f 1-3 | rev | cut -d "." -f 1)"
+
 
 		mkdir -p "$(printf "%sScenery/${scenery_a}/Master/%s\n" "${FG_ROOT}" "$(printf "%s" $tile | rev | cut -d "/" -f 1-2 | rev)")"
-		SCALE_FACTOR="1" FG_ROOT="${FG_ROOT}" FG_SCENERY="${FG_ROOT}Scenery/${scenery_a}/" python3 ${thepwd}/../btg_to_ac3d_2.py "${abtg}" "${FG_ROOT}Scenery/${scenery_a}/Master/$(printf "%s" "${abtg}" | rev | cut -d "/" -f 1-3 | rev | cut -d "." -f 1)-objects.ac"
 
-		masterstg="${FG_ROOT}Scenery/${scenery_a}/Master/$(printf "%s" "${abtg}" | rev | cut -d "/" -f 1-3 | rev | cut -d "." -f 1).stg"
+		SCALE_FACTOR="1" FG_ROOT="${FG_ROOT}" FG_SCENERY="${FG_ROOT}Scenery/${scenery_a}/" \
+		python3 ${thepwd}/../btg_to_ac3d_2.py "${abtg}" "${FG_ROOT}Scenery/${scenery_a}/Master/${fn_subdir_subdir}-objects.ac" > /dev/null
 
-		lonlat="$(python3 ${thepwd}/../tile_calculator.py $(printf "%s" "${abtg}" | rev | cut -d "/" -f 1 | rev | cut -d "." -f 1))"
+		masterstg="${FG_ROOT}Scenery/${scenery_a}/Master/${fn_subdir_subdir}.stg"
+
 		lonlat="$(python3 ${thepwd}/../tile_calculator.py "$fn_no_ext")"
 
 		elevation="$(echo woo $lonlat | FG_ROOT="${FG_ROOT}" FG_SCENERY="${FG_ROOT}Scenery/${scenery_a}/" fgelev | grep woo | cut -d ' ' -f 2)"
 
-		printf "OBJECT_SHARED /Master/%s %s %s 0\n" "$(printf "%s" "${abtg}" | rev | cut -d "/" -f 1-3 | rev | cut -d "." -f 1)-objects.ac" "$lonlat" "$elevation" >> "$masterstg"
+		printf "OBJECT_SHARED /Master/%s %s %s 0\n" "${fn_subdir_subdir}-objects.ac" "$lonlat" "$elevation" >> "$masterstg"
 
-		astg="${FG_ROOT}Scenery/${scenery_b}/Objects/$(printf "%s" "${abtg}" | rev | cut -d "/" -f 1-3 | rev | cut -d "." -f 1).stg"
+		astg="${FG_ROOT}Scenery/${scenery_b}/Objects/${fn_subdir_subdir}.stg"
 		if [ -d "$(dirname "$astg")" ]; then
 			if [ -f "$astg" ]; then
 				cat "$astg" >> "$masterstg"
 			fi
 		fi
 
-		astg="${FG_ROOT}Scenery/${scenery_b}/Pylons/$(printf "%s" "${abtg}" | rev | cut -d "/" -f 1-3 | rev | cut -d "." -f 1).stg"
+		astg="${FG_ROOT}Scenery/${scenery_b}/Pylons/${fn_subdir_subdir}.stg"
 		if [ -d "$(dirname "$astg")" ]; then
 			if [ -f "$astg" ]; then
 				cat "$astg" >> "$masterstg"
 			fi
 		fi
 
-		astg="${FG_ROOT}Scenery/${scenery_b}/Roads/$(printf "%s" "${abtg}" | rev | cut -d "/" -f 1-3 | rev | cut -d "." -f 1).stg"
+		astg="${FG_ROOT}Scenery/${scenery_b}/Roads/${fn_subdir_subdir}.stg"
 		if [ -d "$(dirname "$astg")" ]; then
 			if [ -f "$astg" ]; then
 				cat "$astg" >> "$masterstg"
 			fi
 		fi
 
-		astg="${FG_ROOT}Scenery/${scenery_b}/Buildings/$(printf "%s" "${abtg}" | rev | cut -d "/" -f 1-3 | rev | cut -d "." -f 1).stg"
+		astg="${FG_ROOT}Scenery/${scenery_b}/Buildings/${fn_subdir_subdir}.stg"
 		if [ -d "$(dirname "$astg")" ]; then
 
 			if [ -f "$astg" ]; then
@@ -72,7 +75,7 @@ find "${FG_ROOT}Scenery/${scenery_b}/Terrain" -maxdepth 2 -mindepth 2 -type d | 
 			fi
 		fi
 
-		astg="${FG_ROOT}Scenery/${scenery_b}/Details/$(printf "%s" "${abtg}" | rev | cut -d "/" -f 1-3 | rev | cut -d "." -f 1).stg"
+		astg="${FG_ROOT}Scenery/${scenery_b}/Details/${fn_subdir_subdir}.stg"
 		if [ -d "$(dirname "$astg")" ]; then
 			if [ -f "$astg" ]; then
 				cat "$astg" >> "$masterstg"
@@ -80,7 +83,10 @@ find "${FG_ROOT}Scenery/${scenery_b}/Terrain" -maxdepth 2 -mindepth 2 -type d | 
 		fi
 
 		mkdir -p "$(printf "%s/Final/AC3D/%s\n" "${thepwd}" "$(printf "%s" $tile | rev | cut -d "/" -f 1-2 | rev)")"
-		SCALE_FACTOR="0.001" FG_ROOT="${FG_ROOT}" FG_SCENERY="${FG_ROOT}Scenery/${scenery_a}/" python3 ${thepwd}/../concat_ac3.py "$masterstg" >> "${thepwd}/Final/AC3D/$(printf "%s" "${astg}" | rev | cut -d "/" -f 1-3 | rev | cut -d "." -f 1).ac"
+		astg_subdir_subdir="$(printf "%s" "${astg}" | rev | cut -d "/" -f 1-3 | rev | cut -d "." -f 1)"
+
+		SCALE_FACTOR="0.001" FG_ROOT="${FG_ROOT}" FG_SCENERY="${FG_ROOT}Scenery/${scenery_a}/" \
+		python3 ${thepwd}/../concat_ac3.py "$masterstg" >> "${thepwd}/Final/AC3D/${astg_subdir_subdir}.ac"
 	done
 done
 

--- a/tests/buildScenery.sh
+++ b/tests/buildScenery.sh
@@ -36,8 +36,7 @@ find "${FG_ROOT}Scenery/${scenery_b}/Terrain" -maxdepth 2 -mindepth 2 -type d | 
 
 		masterstg="${FG_ROOT}Scenery/${scenery_a}/Master/$(printf "%s" "${abtg}" | rev | cut -d "/" -f 1-3 | rev | cut -d "." -f 1).stg"
 
-		lonlat="$(python3 ${thepwd}/../tile_calculator.py $(printf "%s" "${abtg}" | rev | cut -d "/" -f 1 | rev | cut -d "." -f 1))"
-		lonlat="$(python3 ${thepwd}/../tile_calculator.py "$fn_no_ext")"
+		lonlat="$(python3 ${thepwd}/../tile_calculator.py -c $(printf "%s" "${abtg}" | rev | cut -d "/" -f 1 | rev | cut -d "." -f 1))"
 
 		elevation="$(echo woo $lonlat | FG_ROOT="${FG_ROOT}" FG_SCENERY="${FG_ROOT}Scenery/${scenery_a}/" fgelev | grep woo | cut -d ' ' -f 2)"
 

--- a/tests/buildScenery.sh
+++ b/tests/buildScenery.sh
@@ -23,6 +23,12 @@ echo $PWD
 find "${FG_ROOT}Scenery/${scenery_b}/Terrain" -maxdepth 2 -mindepth 2 -type d | while read tile; do
 	mkdir -p "$(printf "Final/AC3D/%s\n" "$(printf "%s" $tile | rev | cut -d "/" -f 1-2 | rev)")"
 	find "$tile" -type f -name "*.btg.gz" | while read abtg; do
+    fname="$(basename "${abtg}")"
+    fn_no_ext="${fname%%.*}"
+    # Check that fn_no_ext is a positive integer
+    case $fn_no_ext in
+      ''|*[!0-9]*) echo "Can't get lonlat from $fname, skipping..." ; continue ;;
+    esac
 
 
 		mkdir -p "$(printf "%sScenery/${scenery_a}/Master/%s\n" "${FG_ROOT}" "$(printf "%s" $tile | rev | cut -d "/" -f 1-2 | rev)")"
@@ -31,6 +37,7 @@ find "${FG_ROOT}Scenery/${scenery_b}/Terrain" -maxdepth 2 -mindepth 2 -type d | 
 		masterstg="${FG_ROOT}Scenery/${scenery_a}/Master/$(printf "%s" "${abtg}" | rev | cut -d "/" -f 1-3 | rev | cut -d "." -f 1).stg"
 
 		lonlat="$(python3 ${thepwd}/../tile_calculator.py $(printf "%s" "${abtg}" | rev | cut -d "/" -f 1 | rev | cut -d "." -f 1))"
+		lonlat="$(python3 ${thepwd}/../tile_calculator.py "$fn_no_ext")"
 
 		elevation="$(echo woo $lonlat | FG_ROOT="${FG_ROOT}" FG_SCENERY="${FG_ROOT}Scenery/${scenery_a}/" fgelev | grep woo | cut -d ' ' -f 2)"
 

--- a/tests/initTests.sh
+++ b/tests/initTests.sh
@@ -5,8 +5,6 @@ thepwd="${PWD}"
 
 #get flightgear data
 
-thepwd="$PWD"
-
 mkdir fgdata
 cd fgdata
 
@@ -40,7 +38,7 @@ tar -xf $thepwd/fgdata/e000n50.tgz
 cd ../../
 
 #get Objects
-
+mkdir -p Objects
 cd Objects
 tar -xf $thepwd/fgdata/London-OSM-fg-CustomScenery-master.tar.gz
 

--- a/tests/scenery-object-locParamTest.sh
+++ b/tests/scenery-object-locParamTest.sh
@@ -4,17 +4,25 @@
 
 rm 383925-scenery.ac out.ac atemp.stg #dont worry if this fails, its just to clean up
 
-SCALE_FACTOR="1" FG_ROOT="${PWD}/fgdata/fgdata/" FG_SCENERY="${PWD}/fgdata/fgdata/Scenery/SceneryPack.BIKF/" python3 ${PWD}/../btg_to_ac3d_2.py "fgdata/fgdata/Scenery/SceneryPack.BIKF/Terrain/w160n20/w157n20/383925.btg.gz" "383925-scenery.ac"
+SCALE_FACTOR="1" FG_ROOT="${PWD}/fgdata/fgdata/" FG_SCENERY="${PWD}/fgdata/fgdata/Scenery/SceneryPack.BIKF/" \
+python3 ${PWD}/../btg_to_ac3d_2.py "fgdata/fgdata/Scenery/SceneryPack.BIKF/Terrain/w160n20/w157n20/383925.btg.gz" "383925-scenery.ac"
 
-lonlat="$(python3 ${PWD}/../tile_calculator.py 383925)"
+# Note that with the -c flag added, the below test instructions are unnecessary because the flag fixes the issue
+lonlat="$(python3 ${PWD}/../tile_calculator.py -c 383925)"
 
-elevation="$(echo woo $lonlat | FG_ROOT="${PWD}/fgdata/fgdata/" FG_SCENERY="${PWD}/fgdata/fgdata/Scenery/SceneryPack.BIKF/" fgelev | grep woo | cut -d ' ' -f 2)"
+elevation="$(echo woo $lonlat | \
+FG_ROOT="${PWD}/fgdata/fgdata/" FG_SCENERY="${PWD}/fgdata/fgdata/Scenery/SceneryPack.BIKF/" fgelev \
+| grep woo | \
+cut -d ' ' -f 2)"
 
 printf "OBJECT_SHARED %s/%s %s %s 0 0 90\n" "${PWD}" "383925-scenery.ac" "$lonlat" "$elevation" > atemp.stg
 
 grep "ac " fgdata/fgdata/Scenery/SceneryPack.BIKF/Objects/w160n20/w157n20/383925.stg >> atemp.stg
 
-SCALE_FACTOR="0.001" FG_ROOT="${PWD}/fgdata/fgdata/" FG_SCENERY="${PWD}/fgdata/fgdata/Scenery/SceneryPack.BIKF/" python3 ${PWD}/../concat_ac3.py "atemp.stg" >> "out.ac"
+SCALE_FACTOR="0.001" FG_ROOT="${PWD}/fgdata/fgdata/" FG_SCENERY="${PWD}/fgdata/fgdata/Scenery/SceneryPack.BIKF/" \
+python3 ${PWD}/../concat_ac3.py "atemp.stg" >> "out.ac"
+
+# OLD INSTRUCTIONS TO DEMONSTRATE WHEN THIS TEST USED TO FAIL:
 
 # 2) run
 # 	$ osgviewer out.ac

--- a/tests/test_flightgear_tile.py
+++ b/tests/test_flightgear_tile.py
@@ -1,29 +1,37 @@
-from flightgear_tile import calculate_tile_lat_lon, calculate_tile_index
+import pytest
 
-def test_calculate_tile_lat_lon():
+from tile_calculator import calculate_tile_lon_lat, calculate_tile_index
+
+def test_calculate_tile_lon_lat():
     """
-    We test calculation of lat/lon from tile index
+    We test calculation of lon/lat from tile index
     by using calculate_tile_index()
-    to get the correct index for known lat/lon.
+    to get the correct index for known lon/lat.
     """
     completed_indices = []
     for expected_lat in range(-90, 90):
         for expected_lon in range(-180, 180):
             index = calculate_tile_index(expected_lat, expected_lon)
             if index in completed_indices:
-                # Many lat/lon share the same index, so we only test each index once.
-                # NOTE this means there are many lat/lon for which this test would fail,
-                # because for a given index, we don't know exactly which lat/lon was
-                # used to get it in the first place. Instead, calculate_tile_lat_lon()
-                # can only return the lat/lon of the southwest corner of the specified
+                # Many lon/lat share the same index, so we only test each index once.
+                # NOTE this means there are many lon/lat for which this test would fail,
+                # because for a given index, we don't know exactly which lon/lat was
+                # used to get it in the first place. Instead, calculate_tile_lon_lat()
+                # can only return the lon/lat of the southwest corner of the specified
                 # tile. The order that these for-loops iterate through their coords
                 # is therefore important - by going in the positive direction we are
                 # progressing north-easterly, hitting each tile's southwest corner first.
                 continue
 
-            actual_lat, actual_lon = calculate_tile_lat_lon(index)
+            actual_lat, actual_lon = calculate_tile_lon_lat(index)
 
             assert expected_lat == actual_lat
             assert expected_lon == actual_lon
 
             completed_indices.append(index)
+
+def test_calculate_center_lon_lat():
+    """Now calculate_tile_lon_lat() can return the coords of the center of the tile rather than southwest corner."""
+    expected = (-156.3125, 20.8125)
+    actual = calculate_tile_lon_lat(383925, return_center=True)
+    assert expected == pytest.approx(actual)  # approx because of floating point imprecision

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,9 +21,11 @@ def parse_verts_from_ac(f):
         else:
             # We're not in a block of verts
             if line.startswith("numvert"):
-                # block of verts found
-                numvert = int(line.split()[1])
-                verts_stored = 0
+                # Possible block of verts found
+                this_numvert = int(line.split()[1])
+                if this_numvert > 0:
+                    numvert = this_numvert
+                    verts_stored = 0
 
     return verts
 

--- a/tile_calculator.py
+++ b/tile_calculator.py
@@ -20,6 +20,10 @@ relicenced to GPLv2
 from math import floor, trunc
 import sys
 
+# Standard size of a bucket in degrees (1/8 of a degree)
+SG_BUCKET_SPAN = 0.125
+SG_HALF_BUCKET_SPAN = 0.5 * SG_BUCKET_SPAN
+
 
 # Table of tile widths for various latitudes
 TILE_WIDTHS = (
@@ -47,7 +51,7 @@ def get_tile_width (lat):
     raise Exception("Latitude out of range")
 
 def calculate_tile_index (lon, lat):
-    """ Calculate the index for a lat/lon """
+    """ Calculate the index for a lon/lat """
     
     tile_width = get_tile_width(lat)
     base_y = floor(lat)
@@ -58,14 +62,15 @@ def calculate_tile_index (lon, lat):
 
     return index
 
-def calculate_tile_lat_lon(index: int):
+def calculate_tile_lon_lat(index: int, return_center: bool = False):
     """
-    Calculate the lat/lon for a tile index (southwest corner)
+    Calculate the lon/lat for a tile index (southwest corner OR center)
 
-    Copied from SimGear SGBucket constructor (newbucket.cxx;
+    Copied from SimGear SGBucket (newbucket.hxx; newbucket.cxx;
     1999 Curtis L. Olson - http://www.flightgear.org/~curt/ was the copyright holder)
     """
 
+    # From SGBucket constructor
     lon = index >> 14
     index -= lon << 14
     lon -= 180
@@ -79,18 +84,41 @@ def calculate_tile_lat_lon(index: int):
 
     x = index
 
+    if return_center:
+        # From get_center_lon()
+        span = get_tile_width(lat)
+        if span >= 1.0:
+            lon = lon + span / 2.0
+        else:
+            lon = lon + x * span + span / 2.0
+
+        # From get_center_lat()
+        lat = lat + y / 8.0 + SG_HALF_BUCKET_SPAN
+
     return lon, lat
 
 #
 # Script entry point
 #
 if __name__ == '__main__':
-    if len(sys.argv) == 2:
-        index = int(sys.argv[1])
-        print(*calculate_tile_lat_lon(index))
-    elif len(sys.argv) == 3:
-        lat = float(sys.argv[1])
-        lon = float(sys.argv[2])
+    argv = sys.argv
+
+    if argv[1] == "-c":  # we want the lon/lat of the center of the tile, not its southwest corner
+        return_center = True
+        argv = argv[1:]
+    else:
+        return_center = False
+
+    if len(argv) == 2:
+        index = int(argv[1])
+        print(*calculate_tile_lon_lat(index, return_center))
+    elif len(argv) == 3:
+        if return_center:
+            print("-c option not supported when asking for a tile index, ask for lon/lat instead")
+            exit(1)
+
+        lat = float(argv[1])
+        lon = float(argv[2])
         if lat < -90 or lat > 90:
             print("Latitude {} out of range".format(lat))
             exit(1)
@@ -100,7 +128,7 @@ if __name__ == '__main__':
 
         print(calculate_tile_index(lat, lon))
     else:
-        print(f"Usage:\n  python3 {sys.argv[0]} <lat> <lon>\n  python3 {sys.argv[0]} <index>", file=sys.stderr)
+        print(f"Usage:\n  python3 {argv[0]} <lat> <lon>\n  python3 {argv[0]} <index>", file=sys.stderr)
         exit(2)
 
     exit(0)

--- a/tile_calculator.py
+++ b/tile_calculator.py
@@ -128,7 +128,7 @@ if __name__ == '__main__':
 
         print(calculate_tile_index(lat, lon))
     else:
-        print(f"Usage:\n  python3 {argv[0]} <lat> <lon>\n  python3 {argv[0]} <index>", file=sys.stderr)
+        print(f"Usage:\n  python3 {sys.argv[0]} <lat> <lon>\n  python3 {sys.argv[0]} [-c] <index>", file=sys.stderr)
         exit(2)
 
     exit(0)


### PR DESCRIPTION
fixes #4 

when I run `buildScenery.sh` I get some errors:

- `ValueError: could not convert string to float: ''`
  - looks like the Python is trying to get altitude where there isn't one - `alt = float(splitLine[4])`
- `ValueError: invalid literal for int() with base 10: 'EG31'`
  - `buildScenery.sh` is passing something wrong into `tile_calculator.py`
- `IndexError: list index out of range`
  - My guess is that `splitLine` passed to `processACFile()` is just not what the latter expects
- `/home/x/PycharmProjects/flightgear_export_scripts/tests/buildScenery.sh: 35: fgelev: not found`
  - is this something else that needs installing?

This is what I've changed to fix the aforementioned errors:

- install `fgelev`
- skip `.btg.gz` files that we can't get lonlat from the name of - these are named like `EHBX.btg.gz`, and if we don't skip them, the `OBJECT_SHARED` line gets written out to `$masterstg` in `buildScenery.sh` with no elevation (I assume that's invalid)
- fix a bug (that I introduced) in `concat_ac3.py` where empty vert blocks (beginning `numvert 0` weren't handled properly - this was similarly probably invalidating the final `.ac` files

I've also

- fixed the location issue from the issue
- added some stderr output to `concat_ac3.py` which is useful for debugging
- tidied `buildScenery.sh` (pretty sure I haven't broken anything but worth checking)